### PR TITLE
feat: 데이터 적재를 위한 Apachi POI 추가 및 구현 (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ Desktop.ini
 
 *.pem
 .env
+*.xlsx

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,14 +24,24 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	implementation 'mysql:mysql-connector-java:8.0.33'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// DB
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'mysql:mysql-connector-java:8.0.33'
+
+	// Apachi POI
+	implementation 'org.apache.poi:poi:4.1.2'
+	implementation 'org.apache.poi:poi-ooxml:4.1.2'
+	implementation 'org.apache.poi:poi-ooxml-schemas:4.1.2'
+	implementation 'org.apache.xmlbeans:xmlbeans:3.1.0'
+	implementation 'com.monitorjbl:xlsx-streamer:2.1.0'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/TickerBoard/TickerBoardApplication.java
+++ b/backend/src/main/java/com/example/TickerBoard/TickerBoardApplication.java
@@ -1,7 +1,10 @@
 package com.example.TickerBoard;
 
+import com.example.TickerBoard.global.excel.ExcelDataImporter;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class TickerBoardApplication {
@@ -9,5 +12,12 @@ public class TickerBoardApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(TickerBoardApplication.class, args);
 	}
+
+//	@Bean
+//	CommandLineRunner importData(ExcelDataImporter importer) {
+//		return args -> {
+//			importer.importFromExcel("src/main/resources/StockPrices.xlsx");
+//		};
+//	}
 
 }

--- a/backend/src/main/java/com/example/TickerBoard/domain/StockPrice.java
+++ b/backend/src/main/java/com/example/TickerBoard/domain/StockPrice.java
@@ -25,13 +25,13 @@ public class StockPrice {
     @Column(nullable = false)
     private LocalDate date;
 
-    private Long open;
-    private Long high;
-    private Long low;
-    private Long close;
+    private int open;
+    private int high;
+    private int low;
+    private int close;
     private Long volume;
 
-    @Column(name = "change_rate", precision = 6, scale = 4)
+    @Column(precision = 10, scale = 4)
     private BigDecimal changeRate;
 
 }

--- a/backend/src/main/java/com/example/TickerBoard/global/excel/ExcelDataImporter.java
+++ b/backend/src/main/java/com/example/TickerBoard/global/excel/ExcelDataImporter.java
@@ -1,0 +1,78 @@
+package com.example.TickerBoard.global.excel;
+
+import com.example.TickerBoard.domain.Stock;
+import com.example.TickerBoard.domain.StockPrice;
+import com.example.TickerBoard.repository.StockPriceRepository;
+import com.example.TickerBoard.repository.StockRepository;
+import com.monitorjbl.xlsx.StreamingReader;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class ExcelDataImporter {
+
+    private final StockRepository stockRepository;
+    private final StockPriceRepository stockPriceRepository;
+
+    public void importFromExcel(String path) throws Exception {
+        try (InputStream is = new FileInputStream(path);
+             Workbook workbook = StreamingReader.builder()
+                     .rowCacheSize(100)
+                     .bufferSize(4096)
+                     .open(is)) {
+
+            Sheet sheet = workbook.getSheetAt(0);
+            boolean isHeader = true;
+
+            for (Row row : sheet) {
+                if (isHeader) {
+                    isHeader = false;
+                    continue;
+                }
+
+                String ticker = row.getCell(7).getStringCellValue();
+                String name = row.getCell(8).getStringCellValue();
+                String market = row.getCell(9).getStringCellValue();
+
+                Stock stock = stockRepository.findByTicker(ticker)
+                        .orElseGet(() -> stockRepository.save(
+                                Stock.builder()
+                                        .ticker(ticker)
+                                        .name(name)
+                                        .market(Stock.Market.valueOf(market))
+                                        .build()
+                        ));
+
+                LocalDate date = LocalDate.parse(row.getCell(0).getStringCellValue(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+                StockPrice price = StockPrice.builder()
+                        .stock(stock)
+                        .date(date)
+                        .open((int) row.getCell(1).getNumericCellValue())
+                        .high((int) row.getCell(2).getNumericCellValue())
+                        .low((int) row.getCell(3).getNumericCellValue())
+                        .close((int) row.getCell(4).getNumericCellValue())
+                        .volume((long) row.getCell(5).getNumericCellValue())
+                        .changeRate(BigDecimal.valueOf(row.getCell(6).getNumericCellValue()))
+                        .build();
+
+                stockPriceRepository.save(price);
+            }
+        }
+    }
+
+
+
+}

--- a/backend/src/main/java/com/example/TickerBoard/repository/StockPriceRepository.java
+++ b/backend/src/main/java/com/example/TickerBoard/repository/StockPriceRepository.java
@@ -1,0 +1,13 @@
+package com.example.TickerBoard.repository;
+
+
+import com.example.TickerBoard.domain.StockPrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+public interface StockPriceRepository extends JpaRepository<StockPrice, String> {
+
+    List<StockPrice> findByStock_Ticker(String ticker);
+}

--- a/backend/src/main/java/com/example/TickerBoard/repository/StockRepository.java
+++ b/backend/src/main/java/com/example/TickerBoard/repository/StockRepository.java
@@ -1,0 +1,15 @@
+package com.example.TickerBoard.repository;
+
+import com.example.TickerBoard.domain.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StockRepository extends JpaRepository<Stock, String> {
+
+    List<Stock> findAll();
+
+    Optional<Stock> findByTicker(String ticker);
+}


### PR DESCRIPTION
## 📌 개요
데이터 적재 작업

## ✅ 작업 내용
<!-- 주요 변경사항을 bullet로 정리해주세요 -->
- 엑셀 파일 파싱을 위한 Apachi POI 의존성 주입
- 엑셀 파싱 클래스 구현
- 서버 실행 시 엑셀 파일을 파싱하도록 구현 (현재는 주석 처리)
- 초기 데이터 적재 완료

## 🔗 관련 이슈
<!-- 아래 형식으로 연결된 이슈를 명시해주세요 -->
Closes #7

## 🧪 테스트 방법
<!-- 어떻게 테스트했는지, 테스트하려면 어떤 작업이 필요한지 등을 적어주세요 -->

## 📸 스크린샷 (선택)
<!-- UI 작업인 경우 스크린샷을 첨부해주세요 -->

## 📂 기타 사항
<!-- 리뷰어가 참고하면 좋을 만한 내용을 적어주세요 -->
