### PR TITLE
feat: 종목별 시세 리스트 API 구현 완료 (#13)

### DIFF
--- a/backend/src/main/java/com/example/TickerBoard/service/StockPriceService.java
+++ b/backend/src/main/java/com/example/TickerBoard/service/StockPriceService.java
@@ -1,0 +1,10 @@
+package com.example.TickerBoard.service;
+
+import com.example.TickerBoard.domain.StockPrice;
+
+import java.util.List;
+
+public interface StockPriceService {
+
+    public List<StockPrice> getStockPriceList(String ticker);
+}

--- a/backend/src/main/java/com/example/TickerBoard/service/StockPriceServiceImpl.java
+++ b/backend/src/main/java/com/example/TickerBoard/service/StockPriceServiceImpl.java
@@ -1,0 +1,21 @@
+package com.example.TickerBoard.service;
+
+import com.example.TickerBoard.domain.StockPrice;
+import com.example.TickerBoard.repository.StockPriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockPriceServiceImpl implements StockPriceService {
+
+    private final StockPriceRepository stockPriceRepository;
+
+    @Override
+    public List<StockPrice> getStockPriceList(String ticker) {
+        List<StockPrice> stockPriceList = stockPriceRepository.findByStock_Ticker(ticker);
+        return stockPriceList;
+    }
+}

--- a/backend/src/main/java/com/example/TickerBoard/service/StockService.java
+++ b/backend/src/main/java/com/example/TickerBoard/service/StockService.java
@@ -2,8 +2,10 @@ package com.example.TickerBoard.service;
 
 import com.example.TickerBoard.domain.Stock;
 import java.util.List;
+import java.util.Optional;
 
 public interface StockService {
 
     public List<Stock> getStockList();
+    public Optional<Stock> getStockByTicker(String ticker);
 }

--- a/backend/src/main/java/com/example/TickerBoard/service/StockServiceImpl.java
+++ b/backend/src/main/java/com/example/TickerBoard/service/StockServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +18,10 @@ public class StockServiceImpl implements StockService {
     public List<Stock> getStockList() {
 
         return stockRepository.findAll();
+    }
+
+    @Override
+    public Optional<Stock> getStockByTicker(String ticker) {
+        return stockRepository.findByTicker(ticker);
     }
 }

--- a/backend/src/main/java/com/example/TickerBoard/web/controller/StockController.java
+++ b/backend/src/main/java/com/example/TickerBoard/web/controller/StockController.java
@@ -6,7 +6,6 @@ import com.example.TickerBoard.web.converter.StockConverter;
 import com.example.TickerBoard.web.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
@@ -14,17 +13,16 @@ import java.util.Comparator;
 import java.util.List;
 
 import static com.example.TickerBoard.web.dto.StockDTO.*;
-import static com.example.TickerBoard.web.response.code.FailureCode._FAIL;
-import static com.example.TickerBoard.web.response.code.SuccessCode._OK;
+import static com.example.TickerBoard.web.response.code.FailureCode.STOCK_LIST_NOT_FOUND;
+import static com.example.TickerBoard.web.response.code.SuccessCode.STOCK_FOUND;
 
 @RestController
-@RequestMapping("/stocks")
 @RequiredArgsConstructor
 public class StockController {
 
     private final StockService stockService;
 
-    @GetMapping
+    @GetMapping("/stocks")
     public ApiResponse<List<StocksResponseDTO>> getAllStocks() {
         List<Stock> stockList = stockService.getStockList();
 
@@ -36,9 +34,9 @@ public class StockController {
         stocksResponseDTOList.sort(Comparator.comparing(StocksResponseDTO::getName));
 
         if (stockList.isEmpty()) {
-            return ApiResponse.onFailure(stocksResponseDTOList, _FAIL);
+            return ApiResponse.onFailure(stocksResponseDTOList, STOCK_LIST_NOT_FOUND);
         } else {
-            return ApiResponse.onSuccess(stocksResponseDTOList, _OK);
+            return ApiResponse.onSuccess(stocksResponseDTOList, STOCK_FOUND);
         }
     }
 

--- a/backend/src/main/java/com/example/TickerBoard/web/controller/StockPriceController.java
+++ b/backend/src/main/java/com/example/TickerBoard/web/controller/StockPriceController.java
@@ -1,0 +1,56 @@
+package com.example.TickerBoard.web.controller;
+
+import com.example.TickerBoard.domain.Stock;
+import com.example.TickerBoard.domain.StockPrice;
+import com.example.TickerBoard.service.StockPriceService;
+import com.example.TickerBoard.service.StockService;
+import com.example.TickerBoard.web.converter.StockPriceConverter;
+import com.example.TickerBoard.web.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.TickerBoard.web.dto.StockPriceDTO.*;
+import static com.example.TickerBoard.web.response.code.FailureCode.*;
+import static com.example.TickerBoard.web.response.code.SuccessCode.*;
+
+@RestController
+@RequiredArgsConstructor
+public class StockPriceController {
+
+    private final StockPriceService stockPriceService;
+    private final StockService stockService;
+
+    @GetMapping("/stocks/{ticker}")
+    public ApiResponse<StockPricesResponseDTO> getStockPriceList (@PathVariable("ticker") String ticker) {
+
+        // 티커로 주식 이름 찾기
+        Optional<Stock> stock = stockService.getStockByTicker(ticker);
+        if (stock.isEmpty()) {
+            return ApiResponse.onFailure(null, STOCK_NOT_FOUND);
+        }
+
+        // 주식 가격 리스트 찾기
+        List<StockPrice> stockPriceList = stockPriceService.getStockPriceList(ticker);
+        if (stockPriceList.isEmpty()) {
+            return ApiResponse.onFailure(null, PRICE_NOT_FOUND);
+        }
+
+        // 일자별 종가만 사용
+        List<ClosePriceDTO> closePriceDTOList = new ArrayList<>();
+        for (StockPrice stockPrice : stockPriceList) {
+             closePriceDTOList.add(StockPriceConverter.toClosePriceDTOList(stockPrice));
+        }
+
+        // response 생성
+        StockPricesResponseDTO response = StockPriceConverter.toStockPricesResponseDTO(ticker, stock.get().getName(), closePriceDTOList);
+
+        return ApiResponse.onSuccess(response, PRICE_FOUND);
+
+    }
+}

--- a/backend/src/main/java/com/example/TickerBoard/web/converter/StockPriceConverter.java
+++ b/backend/src/main/java/com/example/TickerBoard/web/converter/StockPriceConverter.java
@@ -1,0 +1,29 @@
+package com.example.TickerBoard.web.converter;
+
+import com.example.TickerBoard.domain.StockPrice;
+
+import java.util.List;
+
+import static com.example.TickerBoard.web.dto.StockPriceDTO.*;
+
+public class StockPriceConverter {
+
+    public static StockPricesResponseDTO toStockPricesResponseDTO(String ticker, String name, List<ClosePriceDTO> closePriceDTOList) {
+
+        return StockPricesResponseDTO.builder()
+                .name(name)
+                .ticker(ticker)
+                .closePriceList(closePriceDTOList)
+                .build();
+
+    }
+
+    public static ClosePriceDTO toClosePriceDTOList(StockPrice stockPrice) {
+
+        return ClosePriceDTO.builder()
+                .date(stockPrice.getDate())
+                .closePrice(stockPrice.getClose())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/example/TickerBoard/web/dto/StockPriceDTO.java
+++ b/backend/src/main/java/com/example/TickerBoard/web/dto/StockPriceDTO.java
@@ -1,0 +1,30 @@
+package com.example.TickerBoard.web.dto;
+
+import com.example.TickerBoard.domain.StockPrice;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class StockPriceDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class StockPricesResponseDTO {
+
+        private String name;
+        private String ticker;
+        private List<ClosePriceDTO> closePriceList;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ClosePriceDTO {
+        private LocalDate date;
+        private int closePrice;
+    }
+}

--- a/backend/src/main/java/com/example/TickerBoard/web/response/code/FailureCode.java
+++ b/backend/src/main/java/com/example/TickerBoard/web/response/code/FailureCode.java
@@ -9,7 +9,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum FailureCode implements BaseCode {
 
-    _FAIL(HttpStatus.BAD_REQUEST, "STOCK4001", "전체 종목 리스트 조회 실패"),
+    // 종목 관련 코드
+    STOCK_LIST_NOT_FOUND(HttpStatus.BAD_REQUEST, "STOCK4001", "전체 종목 리스트 조회 실패"),
+    STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, "STOCK4002", "티커 조회 실패"),
+
+    // 가격 관련 코드
+    PRICE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PRICE4001", "가격 조회 실패"),
 
     ;
 

--- a/backend/src/main/java/com/example/TickerBoard/web/response/code/SuccessCode.java
+++ b/backend/src/main/java/com/example/TickerBoard/web/response/code/SuccessCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessCode implements BaseCode {
 
-    _OK(HttpStatus.OK, "STOCK2001", "전체 종목 리스트 조회 성공"),
+    // 종목 관련 코드
+    STOCK_FOUND(HttpStatus.OK, "STOCK2001", "전체 종목 리스트 조회 성공"),
+
+    // 가격 관련 코드
+    PRICE_FOUND(HttpStatus.OK, "PRICE2001", "주식 가격 리스트 조회 성공"),
 
     ;
 


### PR DESCRIPTION
## 📌 개요
티커로 조회한 종목의 시세 리스트를 조회하는 API를 구현

## ✅ 작업 내용
<!-- 주요 변경사항을 bullet로 정리해주세요 -->
- 티커, 종목 이름, 일자별 종가를 담은 DTO를 정의하여 응답
- DTO, Converter 생성
- 관련된 성공 코드, 실패 코드 정의

## 🔗 관련 이슈
<!-- 아래 형식으로 연결된 이슈를 명시해주세요 -->
Closes #13

## 🧪 테스트 방법
<!-- 어떻게 테스트했는지, 테스트하려면 어떤 작업이 필요한지 등을 적어주세요 -->

## 📸 스크린샷 (선택)
<!-- UI 작업인 경우 스크린샷을 첨부해주세요 -->

## 📂 기타 사항
<!-- 리뷰어가 참고하면 좋을 만한 내용을 적어주세요 -->
추후 티커 번호 수정필요.

AS-IS: 3490
TO-BE: 003490

티커를 6자리 고정으로 변경해야함.
