### PR TITLE
Issue #18 개별 종목 가격 리스트 조회 화면 개발

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "element-plus": "^2.10.7",
-        "vue": "^3.5.17"
+        "vue": "^3.5.17",
+        "vue-chartjs": "^5.3.2",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.0",
@@ -553,6 +556,12 @@
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "license": "MIT"
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@popperjs/core": {
       "name": "@sxzz/popperjs-es",
       "version": "2.11.7",
@@ -946,6 +955,12 @@
         "@vue/shared": "3.5.18"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.18",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.18.tgz",
@@ -1089,6 +1104,18 @@
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
       "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -1493,6 +1520,31 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+      "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "element-plus": "^2.10.7",
-    "vue": "^3.5.17"
+    "vue": "^3.5.17",
+    "vue-chartjs": "^5.3.2",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,45 @@
 <template>
-  <router-view />
+  <div id="app">
+    <!-- 고정 헤더 -->
+    <header class="app-header">
+      <h1 @click="$router.push('/')">📊 TickerBoard</h1>
+    </header>
+
+    <!-- 페이지 내용 -->
+    <main class="app-main">
+      <router-view />
+    </main>
+  </div>
 </template>
 
 <script setup>
-// 여기서는 별도 import 필요 없음
+// App.vue 자체에서는 import 필요 없음
 </script>
+
+<style scoped>
+#app {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background-color: #f5f6fa;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background-color: #2c3e50;
+  color: white;
+  padding: 15px 30px;
+  font-size: 20px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.app-main {
+  flex: 1;
+  padding: 20px;
+}
+
+h1 {
+  text-align: center;
+}
+</style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
-  <Dashboard />
+  <router-view />
 </template>
 
 <script setup>
-import Dashboard from '@/pages/Dashboard.vue'
+// 여기서는 별도 import 필요 없음
 </script>

--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="chart-container">
+    <canvas ref="canvas"></canvas>
+  </div>
+</template>
+
+<script>
+import { onMounted, ref, watch } from 'vue'
+import {
+  Chart, LineController, LineElement, PointElement,
+  LinearScale, Title, CategoryScale, Tooltip, Legend
+} from 'chart.js'
+
+Chart.register(LineController, LineElement, PointElement, LinearScale, Title, CategoryScale, Tooltip, Legend)
+
+export default {
+  name: "LineChart",
+  props: { chartData: Object },
+  setup(props) {
+    const canvas = ref(null)
+    let chart = null
+
+    const renderChart = () => {
+      if (!props.chartData || !props.chartData.labels) return
+      if (chart) chart.destroy()
+
+      chart = new Chart(canvas.value, {
+        type: 'line',
+        data: {
+          labels: props.chartData.labels,   // 👉 x축 (일자)
+          datasets: props.chartData.datasets // 👉 y축 데이터 (종가)
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: {
+            mode: "index",
+            intersect: false, // 선 위에 정확히 올리지 않아도 툴팁 뜸
+          },
+          plugins: {
+            title: {
+              display: true,
+              text: "일자별 종가 추이"
+            },
+            tooltip: {
+              enabled: true,
+              callbacks: {
+                label: function(context) {
+                  let value = context.raw.toLocaleString() + " 원"; // 종가 표시
+                  return `종가: ${value}`;
+                }
+              }
+            },
+            legend: {
+              display: false // "종가" 라벨은 안 보이게 (필요하면 true로 바꿔)
+            }
+          },
+          scales: {
+            x: { title: { display: true, text: "일자" }},
+            y: { title: { display: true, text: "종가 (원)" }}
+          }
+        }
+      })
+    }
+
+    onMounted(renderChart)
+    watch(() => props.chartData, renderChart, { deep: true })
+
+    return { canvas }
+  }
+}
+</script>
+
+<style scoped>
+.chart-container {
+  width: 100%;
+  height: 400px;
+}
+</style>

--- a/frontend/src/components/StockCard.vue
+++ b/frontend/src/components/StockCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-card shadow="hover" class="stock-card">
+    <el-card shadow="hover" class="stock-card" @click="goToDetail">
         <h3>{{ stock.name }}</h3>
         <p>{{ stock.ticker }}</p>
     </el-card>
@@ -13,6 +13,11 @@ export default {
             type: Object,
             required: true,
         }
+    },
+    methods: {
+      goToDetail() {
+        this.$router.push(`/stock/${this.stock.ticker}`)
+      }
     }
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import router from './router'
 import App from './App.vue'
 
 // Element Plus
@@ -6,5 +7,7 @@ import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 
 const app = createApp(App)
+
+app.use(router)
 app.use(ElementPlus)
 app.mount('#app')

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="container">
-    <h1>TickerBoard</h1>
-
+    
     <!-- 검색 + 정렬 -->
     <div class="filter-bar">
       <el-input
@@ -23,7 +22,7 @@
         데이터 불러오는 중...
     </div>
 
-    <!-- 카드 그리드 구성 -->
+    <!-- 카드 그리드 -->
     <el-row :gutter="20" style="margin-top: 20px;">
       <el-col
         v-for="stock in pagedStocks"

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -23,14 +23,22 @@
         데이터 불러오는 중...
     </div>
 
-    <!-- 카드 그리드 -->
+    <!-- 카드 그리드 구성 -->
     <el-row :gutter="20" style="margin-top: 20px;">
       <el-col
         v-for="stock in pagedStocks"
         :key="stock.ticker"
         :xs="24" :sm="12" :md="8" :lg="6"
       >
-        <StockCard :stock="stock" />
+
+        <!-- 카드 -->
+        <router-link
+          :to="{ name: 'StockDetail', params: { ticker: stock.ticker } }"
+          style="text-decoration: none;"
+        >
+          <StockCard :stock="stock" />
+        </router-link>
+
       </el-col>
     </el-row>
 

--- a/frontend/src/pages/StockDetail.vue
+++ b/frontend/src/pages/StockDetail.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="detail-container" v-if="stock">
+    <h2>{{ stock.name }} 상세 정보</h2>
+
+    <!-- 종목 기본 정보 -->
+    <div class="info-box">
+      <p><strong>티커:</strong> {{ stock.ticker }}</p>
+    </div>
+
+    <!-- 차트 -->
+    <LineChart v-if="chartData.datasets.length" :chartData="chartData" />
+  </div>
+
+  <div v-else class="loading">
+    데이터를 불러오는 중입니다...
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import LineChart from '@/components/LineChart.vue'
+
+export default {
+  name: "StockDetail",
+  components: { LineChart },
+  setup() {
+    const route = useRoute()
+    const stock = ref(null)
+    const chartData = ref({
+      labels: [],
+      datasets: []
+    })
+
+    onMounted(async () => {
+      try {
+        const res = await fetch(`http://localhost:8080/stocks/${route.params.ticker}`)
+        const data = await res.json()
+
+        stock.value = data.result
+
+        if (stock.value && stock.value.closePriceList) {
+          chartData.value = {
+            labels: stock.value.closePriceList.map(p => p.date), // yyyy-mm-dd 그대로
+            datasets: [
+              {
+                label: "종가",
+                data: stock.value.closePriceList.map(p => p.closePrice),
+                borderColor: "blue",
+                backgroundColor: "rgba(0, 0, 255, 0.1)",
+                fill: true,
+                tension: 0.3
+              }
+            ]
+          }
+        }
+      } catch (err) {
+        console.error("API 호출 실패", err)
+      }
+    })
+
+    return { stock, chartData }
+  }
+}
+</script>
+
+<style scoped>
+.detail-container {
+  max-width: 900px;
+  margin: auto;
+  padding: 20px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.info-box {
+  margin-bottom: 20px;
+  font-size: 16px;
+}
+
+.loading {
+  text-align: center;
+  margin-top: 50px;
+  font-size: 18px;
+  color: #555;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,0 +1,15 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import Dashboard from '@/pages/Dashboard.vue'
+import StockDetail from '@/pages/StockDetail.vue'
+
+const routes = [
+  { path: '/', name: 'Dashboard', component: Dashboard },
+  { path: '/stocks/:ticker', name: 'StockDetail', component: StockDetail }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+export default router


### PR DESCRIPTION
## 📌 개요
개별 종목 조회시 해당 종목의 차트를 보여주는 화면 개발

## ✅ 작업 내용
<!-- 주요 변경사항을 bullet로 정리해주세요 -->
- 대시보드에서 종목 카드 클릭시 개별 종목으로 라우팅
- 데이터를 기반으로 (일자별 종가) 차트 생성 -> chart.js 사용
- 대시보드의 헤더를 화면이 바뀌더라도 고정

## 🔗 관련 이슈
<!-- 아래 형식으로 연결된 이슈를 명시해주세요 -->
Closes #18 

## 🧪 테스트 방법
<!-- 어떻게 테스트했는지, 테스트하려면 어떤 작업이 필요한지 등을 적어주세요 -->

## 📸 스크린샷 (선택)
<!-- UI 작업인 경우 스크린샷을 첨부해주세요 -->

## 📂 기타 사항
<!-- 리뷰어가 참고하면 좋을 만한 내용을 적어주세요 -->
